### PR TITLE
Fallback to RegExp if re2 is not installed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
-const RE2 = require('re2');
 const ipRegex = require('ip-regex');
 const tlds = require('tlds');
 
 /* istanbul ignore next */
-const SafeRegExp = typeof RE2 === 'function' ? RE2 : RegExp;
+const SafeRegExp = (() => {
+  try {
+    const RE2 = require('re2');
+    return typeof RE2 === 'function' ? RE2 : RegExp;
+  } catch {
+    return RegExp;
+  }
+})();
 const ipv4 = ipRegex.v4().source;
 const ipv6 = ipRegex.v6().source;
 


### PR DESCRIPTION
Fixes issue #6 - I used the exact same code that you also use in your `url-regex-safe` package.

You planned a PR to fix issue #6 but this pull request was never made. Hence I created it now. As instructed by @titanism in his last comment, I didn’t bump the version to `3.0.0` so that you can do it yourself with `np`.